### PR TITLE
added whitelist for bean deserialization

### DIFF
--- a/ant/build-test.xml
+++ b/ant/build-test.xml
@@ -100,7 +100,9 @@ test.run.interop, test.run.jaxrs, test.run.failing, test.run.versions"
     />
     <target name="test.run.main" depends="test.compile">
        <!-- showoutput 'yes' to allow outputting debug msgs... -->
-        <junit fork="no" printsummary="yes" haltonfailure="no" showoutput="yes">
+       <junit fork="no" printsummary="yes" haltonfailure="no" showoutput="yes">
+	   <sysproperty key="jackson.deserialization.whitelist.packages"
+            value="org.codehaus.jackson,java.awt.Point,java.io.File,java.util.concurrent.atomic,java.io.Serializable"/>
             <batchtest fork="no" todir="${dir.test.xmlresults}">
                 <fileset dir="${dir.test.classes}">
                     <!-- Need to exclude inner classes... -->
@@ -129,7 +131,9 @@ test.run.interop, test.run.jaxrs, test.run.failing, test.run.versions"
 
     <target name="test.run.interop" depends="test.compile">
         <!-- for interop tests, yes, we need to fork (classloading issues) -->
-        <junit fork="yes" printsummary="yes" haltonfailure="no" showoutput="yes">
+	<junit fork="yes" printsummary="yes" haltonfailure="no" showoutput="yes">
+	    <sysproperty key="jackson.deserialization.whitelist.packages"
+            	value="org.codehaus.jackson,GBean"/>
             <batchtest fork="no" todir="${dir.test.xmlresults}">
                 <fileset dir="${dir.test.classes}">
                     <exclude name="**/*$*.class"/>
@@ -154,7 +158,9 @@ test.run.interop, test.run.jaxrs, test.run.failing, test.run.versions"
 
     <target name="test.run.jaxrs" depends="test.compile">
         <!-- And finally, minimal testing for jax-rs too -->
-        <junit fork="yes" printsummary="yes" haltonfailure="no" showoutput="yes">
+	<junit fork="yes" printsummary="yes" haltonfailure="no" showoutput="yes">
+	    <sysproperty key="jackson.deserialization.whitelist.packages"
+                value="org.codehaus.jackson"/>
             <batchtest fork="no" todir="${dir.test.xmlresults}">
                 <fileset dir="${dir.test.classes}">
                     <exclude name="**/*$*.class"/>


### PR DESCRIPTION
Jackson 1 is prone to deserialization attacks as discussed by Moritz Bechler in his [MarshalSec research](https://github.com/mbechler/marshalsec/blob/master/marshalsec.pdf). This patch disables the dangerous features of Jackson 1 but allows a user to supply a whitelist of packages allowed to be unmarshalled.
If an unexpected class is attempted to be unmarshalled a JsonMappingException is throw similar to what has been [implemented in Jackson 2](https://github.com/FasterXML/jackson-databind/commit/6ce32ffd18facac6abdbbf559c817b47fcb622c1). A user on receiving this exception can re-run their application with a System Property  "**jackson.deserialization.whitelist.packages**" which adds the fully qualified class name or package name of the class they would expect to be deserialized.